### PR TITLE
Add namespace to fix issue with build appbundle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    namespace "com.memphisNguyen.charset_converter"
+    namespace "pl.pr0gramista.charset_converter"
     compileSdkVersion 28
 
     sourceSets {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace "com.memphisNguyen.charset_converter"
     compileSdkVersion 28
 
     sourceSets {


### PR DESCRIPTION
On running appbundle build, I got below error

```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':charset_converter'.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Specify a namespace in the module's build file. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.

     If you've specified the package attribute in the source AndroidManifest.xml, you can use the AGP Upgrade Assistant to migrate to the namespace value in the build file. Refer to https://d.android.com/r/tools/upgrade-assistant/agp-upgrade-assistant for general information about using the AGP Upgrade Assistant.
```

Adding the missing namespace to bypass the error