### PR TITLE
Bump compileSdkVersion

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 
 android {
     namespace "pl.pr0gramista.charset_converter"
-    compileSdkVersion 28
+    compileSdkVersion 34
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'


### PR DESCRIPTION
Appears to fix the AAPT / lStar error in Flutter 3.24.0 (#40)