### PR TITLE
remove unnecessary appending of null bytes in FlValue as length is known

### DIFF
--- a/lib/charset_converter.dart
+++ b/lib/charset_converter.dart
@@ -50,9 +50,7 @@ class CharsetConverter {
   static Future<String> decode(String charset, Uint8List data) async {
     final result = await _channel.invokeMethod('decode', {
       "charset": charset,
-      // A bit silly, but GLib string (gchar *) is the same as C's, the end of the string must be '\0'.
-      // We are bad at C so we handle it here.
-      "data": Platform.isLinux ? Uint8List.fromList([...data, 0]) : data,
+      "data": data,
     });
 
     if (result == null) {


### PR DESCRIPTION
Hi,

This PR removes a useless copy of the input string when decoding in Linux because the glib function (`g_convert_with_iconv`) actually does not expect a C-string but an array of gchar with the actual length (length may be set to `-1` for null-terminated string).

When obtaining the string on the C side:
```
    FlValue *data = fl_value_lookup_string(args, "data");
    gchar *toUse = (gchar *)fl_value_get_uint8_list(data);
    gsize charlen = fl_value_get_length(data);
```

`charlen` will effectively encode the string length so  `toUse` does not require to end with a null byte :)

